### PR TITLE
an odom counter added for testing

### DIFF
--- a/vertigo/examples/robustISAM2/robustISAM2-3d.cpp
+++ b/vertigo/examples/robustISAM2/robustISAM2-3d.cpp
@@ -275,6 +275,7 @@ int main(int argc, char *argv[])
 
     int counter=0;
     int switchCounter=-1;
+    int odomCounter = 0;
 
     fullSLAM::Values globalInitialEstimate;
 //    Timer timer;
@@ -301,7 +302,8 @@ int main(int argc, char *argv[])
     	  // see if this is an odometry edge, if yes, use it to initialize the current pose
     	  if (e.j==e.i+1) {
 //    	    timer.tic("initialize");
-
+          odomCounter++;
+          cout << "Number of odom constraints is: " << odomCounter << endl;
           Pose3 predecessorPose = isam2.calculateEstimate<Pose3>(fullSLAM::PoseKey(p.id-1));
 //          cout << "predecessor pose: rot:\n " << predecessorPose.rotation() << "\n translation is: \n" << predecessorPose.translation() << endl;
 


### PR DESCRIPTION
In this branch:

- A 3D SLAM has been developed for integration with switch variable.
- It has been tested with sphere2500.
TODO:

- [ ] the optimisation problem sometimes diverge and the program stops because of ill-conditioned situation. It might be because of the dataset. I need to try the original data from Michael Kaess's website.

- [ ] I need to try the more advance cost functions such as Huber to deal with the outliers not recognisable with the switch variable.

- [ ] I need to test the switch variable on a dataset created from our own SLAM.